### PR TITLE
Enable mysql tests with docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,18 @@
+# sudo is required for docker
+sudo: required
+
 language: go
+
+services:
+    - docker
+
+before_install:
+    docker pull mysql:5.6
+
+
+# With the "docker" tag enabled,
+# the mysql:5.6 docker container will be started
+# and the mysql tests will connect to this container
+script: go test -v -tags docker  ./...
+
+


### PR DESCRIPTION
Configure travis with support for docker, and enable the "docker" build tag in
tests.

This will enable the mysql related tests, which run against the mysql container.