### PR TITLE
Add debug logging for "eligible" CLI command

### DIFF
--- a/command/eligible.go
+++ b/command/eligible.go
@@ -22,11 +22,15 @@ import (
 	"github.com/Netflix/chaosmonkey/deploy"
 	"github.com/Netflix/chaosmonkey/grp"
 	"github.com/Netflix/chaosmonkey/term"
+
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 // Eligible prints out a list of instance ids eligible for termination
 // It is intended only for testing
 func Eligible(g chaosmonkey.AppConfigGetter, d deploy.Deployment, app, account, region, stack, cluster string) {
+	jww.SetStdoutThreshold(jww.LevelDebug)
+
 	cfg, err := g.Get(app)
 	if err != nil {
 		fmt.Printf("Failed to retrieve config for app %s\n%+v", app, err)
@@ -34,6 +38,8 @@ func Eligible(g chaosmonkey.AppConfigGetter, d deploy.Deployment, app, account, 
 	}
 
 	group := grp.New(app, account, region, stack, cluster)
+
+	jww.DEBUG.Printf("identifying eligible instances for chaos monkey group: {%s}", group)
 	pApp, err := d.GetApp(app)
 	if err != nil {
 		fmt.Printf("GetApp failed for app %s\n%+v", app, err)

--- a/deploy/asg.go
+++ b/deploy/asg.go
@@ -14,7 +14,11 @@
 
 package deploy
 
-import frigga "github.com/SmartThingsOSS/frigga-go"
+import (
+	"fmt"
+
+	frigga "github.com/SmartThingsOSS/frigga-go"
+)
 
 // ASG identifies an autoscaling group in the deployment
 type ASG struct {
@@ -38,6 +42,11 @@ func NewASG(name, region string, instanceIDs []string, cluster *Cluster) *ASG {
 	}
 
 	return &result
+}
+
+// String returns a string representation
+func (a *ASG) String() string {
+	return fmt.Sprintf("name:%s account:%s region:%s", a.Name(), a.AccountName(), a.RegionName())
 }
 
 // Instances returns a slice of the instances associated with the ASG

--- a/grp/grp.go
+++ b/grp/grp.go
@@ -138,6 +138,10 @@ type group struct {
 	app, account, region, stack, cluster string
 }
 
+func (g group) String() string {
+	return String(g)
+}
+
 func (g group) MarshalJSON() ([]byte, error) {
 	var s = struct {
 		App     string `json:"app"`


### PR DESCRIPTION
To add in debugging chaos monkey issues with a deployment, when the user calls
"chaosmonkey eligible ...", show some additional debug statements to help users
identify why chaos monkey may not be recognizing instances as eligible for
termination.