### PR TITLE
spelling fixes

### DIFF
--- a/command/chaosmonkey.go
+++ b/command/chaosmonkey.go
@@ -191,7 +191,7 @@ func Execute() {
 		log.Fatalf("FATAL: failed to load config: %v", err)
 	}
 
-	// Associate config values with falgs
+	// Associate config values with flags
 	err = cfg.BindPFlag(param.MaxApps, flag.Lookup(maxAppsFlag))
 	if err != nil {
 		log.Fatalf("FATAL: failed to bind flag: --%s: %v", maxAppsFlag, err)

--- a/deploy/eligible_instance_groups.go
+++ b/deploy/eligible_instance_groups.go
@@ -25,7 +25,7 @@ import (
 // EligibleInstanceGroups returns a slice of InstanceGroups that represent
 // groups of instances that are eligible for termination.
 //
-// Note that this code does not check for violations of mininum time between
+// Note that this code does not check for violations of minimum time between
 // terminations. Chaos Monkey checks that precondition immediately before
 // termination, not when considering groups of eligible instances.
 //

--- a/vendor/golang.org/x/crypto/ssh/certs.go
+++ b/vendor/golang.org/x/crypto/ssh/certs.go
@@ -320,7 +320,7 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 // the signature of the certificate.
 func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	if c.IsRevoked != nil && c.IsRevoked(cert) {
-		return fmt.Errorf("ssh: certificate serial %d revoked", cert.Serial)
+		return fmt.Errorf("ssh: certicate serial %d revoked", cert.Serial)
 	}
 
 	for opt, _ := range cert.CriticalOptions {

--- a/vendor/golang.org/x/crypto/ssh/certs.go
+++ b/vendor/golang.org/x/crypto/ssh/certs.go
@@ -320,7 +320,7 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 // the signature of the certificate.
 func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	if c.IsRevoked != nil && c.IsRevoked(cert) {
-		return fmt.Errorf("ssh: certicate serial %d revoked", cert.Serial)
+		return fmt.Errorf("ssh: certificate serial %d revoked", cert.Serial)
 	}
 
 	for opt, _ := range cert.CriticalOptions {


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.