### PR TITLE
fix: Disable Spinnaker app endpoint expansion

### DIFF
--- a/spinnaker/config.go
+++ b/spinnaker/config.go
@@ -25,7 +25,8 @@ import (
 
 // Get implements chaosmonkey.Getter.Get
 func (s Spinnaker) Get(app string) (c *chaosmonkey.AppConfig, err error) {
-	url := s.appURL(app)
+	// avoid expanding the response to avoid unneeded load
+	url := s.appURL(app) + "?expand=false"
 	resp, err := s.client.Get(url)
 	if err != nil {
 		return nil, errors.Wrapf(err, "http get failed at %s", url)


### PR DESCRIPTION
The default behavior for the `/applications/{appName}` Spinnaker endpoint
will expand to return metadata for all clusters for the given application.
In most cases, this is fine, but for large applications that have thousands
of clusters, this can cause damaging high load.

@lorin @tomaslin PTAL