### PR TITLE
Remove a spurious "%v"

### DIFF
--- a/term/term.go
+++ b/term/term.go
@@ -167,7 +167,7 @@ func doTerminate(d deps.Deps, group grp.InstanceGroup) error {
 	for _, tracker := range d.Trackers {
 		err = tracker.Track(trm)
 		if err != nil {
-			return errors.Wrap(err, "not terminating: recording termination event failed: %v")
+			return errors.Wrap(err, "not terminating: recording termination event failed")
 		}
 	}
 


### PR DESCRIPTION
Since we're using errors.Wrap, we don't use "%v" to interpolate the error
message.