### PR TITLE
Handle case with app-level configs and region-specific cluster names

### DIFF
--- a/constrainer/constrainer.go
+++ b/constrainer/constrainer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Netflix/chaosmonkey/schedule"
 )
 
+// NullConstrainer is a no-op constrainer
 type NullConstrainer struct{}
 
 func init() {

--- a/eligible/eligible.go
+++ b/eligible/eligible.go
@@ -151,14 +151,14 @@ func clusters(group grp.InstanceGroup, cloudProvider deploy.CloudProvider, exs [
 func regions(group grp.InstanceGroup, deployedRegions []deploy.RegionName) []deploy.RegionName {
 	region, ok := group.Region()
 	if ok {
-		return regionsWhenConfiguredForSingleRegion(region, deployedRegions)
+		return regionsWhenTermScopedtoSingleRegion(region, deployedRegions)
 	}
 
 	return deployedRegions
 }
 
-// regionsWhenConfiguredForSingleRegion returns a list containing either the region or empty, depending on whether the region is one of the deployed ones
-func regionsWhenConfiguredForSingleRegion(region string, deployedRegions []deploy.RegionName) []deploy.RegionName {
+// regionsWhenTermScopedtoSingleRegion returns a list containing either the region or empty, depending on whether the region is one of the deployed ones
+func regionsWhenTermScopedtoSingleRegion(region string, deployedRegions []deploy.RegionName) []deploy.RegionName {
 	if contains(region, deployedRegions) {
 		return []deploy.RegionName{deploy.RegionName(region)}
 	}

--- a/eligible/eligible.go
+++ b/eligible/eligible.go
@@ -151,14 +151,14 @@ func clusters(group grp.InstanceGroup, cloudProvider deploy.CloudProvider, exs [
 func regions(group grp.InstanceGroup, deployedRegions []deploy.RegionName) []deploy.RegionName {
 	region, ok := group.Region()
 	if ok {
-		return regionsWhenAppSpecifiesSingleRegion(region, deployedRegions)
+		return regionsWhenConfiguredForSingleRegion(region, deployedRegions)
 	}
 
 	return deployedRegions
 }
 
-// regionsWhenAppSpecifiesSingleRegion returns a list containing either the region or empty, depending on whether the region is one of the deployed ones
-func regionsWhenAppSpecifiesSingleRegion(region string, deployedRegions []deploy.RegionName) []deploy.RegionName {
+// regionsWhenConfiguredForSingleRegion returns a list containing either the region or empty, depending on whether the region is one of the deployed ones
+func regionsWhenConfiguredForSingleRegion(region string, deployedRegions []deploy.RegionName) []deploy.RegionName {
 	if contains(region, deployedRegions) {
 		return []deploy.RegionName{deploy.RegionName(region)}
 	}

--- a/eligible/eligible.go
+++ b/eligible/eligible.go
@@ -117,8 +117,7 @@ func clusters(group grp.InstanceGroup, cloudProvider deploy.CloudProvider, exs [
 			return nil, err
 		}
 
-		var deployedRegions []deploy.RegionName
-		deployedRegions, err = dep.GetRegionNames(names.App, account, clusterName)
+		deployedRegions, err := dep.GetRegionNames(names.App, account, clusterName)
 		if err != nil {
 			return nil, err
 		}
@@ -152,14 +151,19 @@ func clusters(group grp.InstanceGroup, cloudProvider deploy.CloudProvider, exs [
 func regions(group grp.InstanceGroup, deployedRegions []deploy.RegionName) []deploy.RegionName {
 	region, ok := group.Region()
 	if ok {
-		if contains(region, deployedRegions) {
-			return []deploy.RegionName{deploy.RegionName(region)}
-		} else {
-			return nil
-		}
-	}  else {
-		return deployedRegions
+		return regionsWhenAppSpecifiesSingleRegion(region, deployedRegions)
 	}
+
+	return deployedRegions
+}
+
+// regionsWhenAppSpecifiesSingleRegion returns a list containing either the region or empty, depending on whether the region is one of the deployed ones
+func regionsWhenAppSpecifiesSingleRegion(region string, deployedRegions []deploy.RegionName) []deploy.RegionName {
+	if contains(region, deployedRegions) {
+		return []deploy.RegionName{deploy.RegionName(region)}
+	}
+
+	return nil
 }
 
 func contains(region string, regions []deploy.RegionName) bool {

--- a/eligible/eligible_test.go
+++ b/eligible/eligible_test.go
@@ -128,7 +128,6 @@ func TestAppLevelGroupingWhereClusterIsInTwoRegions(t *testing.T) {
 	}
 }
 
-
 func TestExceptions(t *testing.T) {
 	tests := []struct {
 		label string

--- a/eligible/eligible_test.go
+++ b/eligible/eligible_test.go
@@ -107,6 +107,28 @@ func TestAppLevelGroupingWhereClustersAreRegionSpecific(t *testing.T) {
 	}
 }
 
+func TestAppLevelGroupingWhereClusterIsInTwoRegions(t *testing.T) {
+	dep := &mock.Deployment{AppMap: map[string]D.AppMap{
+		"foo": {"prod": D.AccountInfo{CloudProvider: "aws", Clusters: D.ClusterMap{
+			"foo-prod": {
+				"us-east-1": {"foo-prod-v001": []D.InstanceID{"i-11111111", "i-22222222", "i-33333333"}},
+				"us-west-2": {"foo-prod-v001": []D.InstanceID{"i-aaaaaaaa", "i-bbbbbbbb", "i-cccccccc"}},
+			},
+		}}}}}
+
+	group := grp.New("foo", "prod", "", "", "")
+
+	instances, err := Instances(group, nil, dep)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if got, want := len(instances), 6; got != want {
+		t.Errorf("got: %d, want: %d", got, want)
+	}
+}
+
+
 func TestExceptions(t *testing.T) {
 	tests := []struct {
 		label string

--- a/eligible/eligible_test.go
+++ b/eligible/eligible_test.go
@@ -95,7 +95,7 @@ func TestAppLevelGroupingWhereClustersAreRegionSpecific(t *testing.T) {
 		}},
 		}}}
 
-		group := grp.New("foo", "prod", "us-east-1", "", "")
+	group := grp.New("foo", "prod", "us-east-1", "", "")
 
 	instances, err := Instances(group, nil, dep)
 	if err != nil {

--- a/eligible/eligible_test.go
+++ b/eligible/eligible_test.go
@@ -83,6 +83,30 @@ func TestGroupings(t *testing.T) {
 	}
 }
 
+func TestAppLevelGroupingWhereClustersAreRegionSpecific(t *testing.T) {
+	dep := &mock.Deployment{AppMap: map[string]D.AppMap{
+		"foo": {"prod": D.AccountInfo{CloudProvider: "aws", Clusters: D.ClusterMap{
+			"foo-useast1": {
+				"us-east-1": {"foo-useast1-v001": []D.InstanceID{"i-11111111", "i-22222222", "i-33333333"}},
+			},
+			"foo-uswest2": {
+				"us-west-2": {"foo-uswest2-v005": []D.InstanceID{"i-cccccccc", "i-dddddddd"}},
+			},
+		}},
+		}}}
+
+		group := grp.New("foo", "prod", "us-east-1", "", "")
+
+	instances, err := Instances(group, nil, dep)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if got, want := len(instances), 3; got != want {
+		t.Errorf("got: %d, want: %d", got, want)
+	}
+}
+
 func TestExceptions(t *testing.T) {
 	tests := []struct {
 		label string


### PR DESCRIPTION
Previously, if an app was configured with app-level scope, and the cluster names varied by region, then Chaos Monkey would not handle this case correctly: it would assume that all clusters existed in all
regions, and then fail on 404s from Spinnaker.

With this PR, Chaos Monkey will no longer query Spinnaker for non-existent clusters in a region.