### PR TITLE
Update frigga-go dependency

### DIFF
--- a/vendor/github.com/SmartThingsOSS/frigga-go/names.go
+++ b/vendor/github.com/SmartThingsOSS/frigga-go/names.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	nameChars       = "a-zA-Z0-9\\._"
-	nameHyphenChars = "\\-a-zA-Z0-9\\._"
+	nameChars       = "a-zA-Z0-9\\._\\^"
+	nameHyphenChars = "\\-a-zA-Z0-9\\._\\^"
 
 	// Deviation from Frigga: SmartThings allows for more than 3 characters in the
 	// push format, as well as underscore values! This does not affect the test

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "QNUzQ9hC5R53WM0cQCDcM2esqMI=",
+			"checksumSHA1": "X5fYX+aczewfHRL0FYoG0F0Lhjs=",
 			"path": "github.com/SmartThingsOSS/frigga-go",
-			"revision": "ecc2955753f6282fde28c6cb95e779aef7e8898c",
-			"revisionTime": "2016-07-26T13:24:17-05:00"
+			"revision": "55b2c36db3e755eec17627a5a50265064ce3ad7a",
+			"revisionTime": "2018-08-27T23:07:14Z"
 		},
 		{
 			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",


### PR DESCRIPTION
Update to latest frigga-go, which supports caret (^) in the name of a cluster.