### PR TITLE
Fix vet error:

### DIFF
--- a/mock/deployment.go
+++ b/mock/deployment.go
@@ -127,7 +127,7 @@ func (d Deployment) GetInstanceIDs(app string, account D.AccountName, cloudProvi
 
 	clusterInfo, ok := accountInfo.Clusters[cluster]
 	if !ok {
-		return "", nil, errors.Errorf("no cluster %s in app:%s, account:%s", cluster)
+		return "", nil, errors.Errorf("no cluster %s in app:%s, account:%s", cluster, app, account)
 	}
 
 	asgs, ok := clusterInfo[region]


### PR DESCRIPTION
# github.com/Netflix/chaosmonkey/mock
github.com/Netflix/chaosmonkey/mock/deployment.go:130: Errorf format %s reads arg #2, but call has 1 arg