### PR TITLE
Meaningful error message for wrong account name

### DIFF
--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -481,9 +481,9 @@ func (s Spinnaker) asgs(appName, account, clusterName string) (result []spinnake
 
 // CloudProvider returns the cloud provider for a given account
 func (s Spinnaker) CloudProvider(account string) (provider string, err error) {
-	exist, e := s.existsAccount(account)
-	if e != nil {
-		return "", e
+	exist, err := s.existsAccount(account)
+	if err != nil {
+		return "", err
 	}
 	if !exist {
 		return "", errors.New("the account name doesn't exist")
@@ -531,7 +531,8 @@ func (s Spinnaker) CloudProvider(account string) (provider string, err error) {
 	return fields.CloudProvider, nil
 }
 
-func (s Spinnaker) existsAccount(account string) (bool, error) {
+// existsAccount checks the existence of an account by its name
+func (s Spinnaker) existsAccount(name string) (bool, error) {
 	url := s.credentialsURL()
 	resp, err := s.client.Get(url)
 	if err != nil {
@@ -554,7 +555,7 @@ func (s Spinnaker) existsAccount(account string) (bool, error) {
 		Type string `json:"type"`
 	}
 
-	var credentials = make([]credential, 0)
+	credentials := make([]credential, 0)
 
 	err = json.Unmarshal(body, &credentials)
 	if err != nil {
@@ -562,7 +563,7 @@ func (s Spinnaker) existsAccount(account string) (bool, error) {
 	}
 
 	for _, c := range credentials {
-		if c.Name == account {
+		if c.Name == name {
 			return true, nil
 		}
 	}

--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -487,7 +487,7 @@ func (s Spinnaker) CloudProvider(name string) (provider string, err error) {
 	}
 
 	if account.CloudProvider == "" {
-		return "", fmt.Errorf("no cloudProvider field in response body")
+		return "", errors.New("no cloudProvider field in response body")
 	}
 
 	return account.CloudProvider, nil

--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -507,7 +507,7 @@ func (s Spinnaker) account(name string) (*account, error) {
 
 	// Usual HTTP checks
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("http get failed at %s", url))
+		return nil, errors.Wrapf(err, "http get failed at %s", url)
 	}
 
 	defer func() {
@@ -518,10 +518,10 @@ func (s Spinnaker) account(name string) (*account, error) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("body read failed at %s", url))
+		return nil, errors.Wrapf(err, "body read failed at %s", url)
 	}
 
-	accounts := make([]account, 0)
+	var accounts []account
 	err = json.Unmarshal(body, &accounts)
 	if err != nil {
 		return nil, errors.Wrap(err, "json unmarshal failed")
@@ -535,10 +535,10 @@ func (s Spinnaker) account(name string) (*account, error) {
 		}
 		if statusKO {
 			if a.Error == "" {
-				return nil, fmt.Errorf("unexpected status code: %d. body: %s", resp.StatusCode, body)
+				return nil, errors.Errorf("unexpected status code: %d. body: %s", resp.StatusCode, body)
 			}
 
-			return nil, fmt.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, a.Error)
+			return nil, errors.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, a.Error)
 		}
 
 		return &a, nil

--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -501,13 +501,14 @@ type account struct {
 }
 
 // account returns an account by its name
-func (s Spinnaker) account(name string) (*account, error) {
+func (s Spinnaker) account(name string) (account, error) {
 	url := s.accountsURL(true)
 	resp, err := s.client.Get(url)
+	var ac account
 
 	// Usual HTTP checks
 	if err != nil {
-		return nil, errors.Wrapf(err, "http get failed at %s", url)
+		return ac, errors.Wrapf(err, "http get failed at %s", url)
 	}
 
 	defer func() {
@@ -518,13 +519,13 @@ func (s Spinnaker) account(name string) (*account, error) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrapf(err, "body read failed at %s", url)
+		return ac, errors.Wrapf(err, "body read failed at %s", url)
 	}
 
 	var accounts []account
 	err = json.Unmarshal(body, &accounts)
 	if err != nil {
-		return nil, errors.Wrap(err, "json unmarshal failed")
+		return ac, errors.Wrap(err, "json unmarshal failed")
 	}
 	statusKO := resp.StatusCode != http.StatusOK
 
@@ -535,16 +536,16 @@ func (s Spinnaker) account(name string) (*account, error) {
 		}
 		if statusKO {
 			if a.Error == "" {
-				return nil, errors.Errorf("unexpected status code: %d. body: %s", resp.StatusCode, body)
+				return ac, errors.Errorf("unexpected status code: %d. body: %s", resp.StatusCode, body)
 			}
 
-			return nil, errors.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, a.Error)
+			return ac, errors.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, a.Error)
 		}
 
-		return &a, nil
+		return a, nil
 	}
 
-	return nil, errors.New("the account name doesn't exist")
+	return ac, errors.New("the account name doesn't exist")
 }
 
 // GetClusterNames returns a list of cluster names for an app

--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -529,19 +529,19 @@ func (s Spinnaker) account(name string) (*account, error) {
 	statusKO := resp.StatusCode != http.StatusOK
 
 	// Finally find account
-	for _, c := range accounts {
-		if c.Name != name {
+	for _, a := range accounts {
+		if a.Name != name {
 			continue
 		}
 		if statusKO {
-			if c.Error == "" {
+			if a.Error == "" {
 				return nil, fmt.Errorf("unexpected status code: %d. body: %s", resp.StatusCode, body)
 			}
 
-			return nil, fmt.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, c.Error)
+			return nil, fmt.Errorf("unexpected status code: %d. error: %s", resp.StatusCode, a.Error)
 		}
 
-		return &c, nil
+		return &a, nil
 	}
 
 	return nil, errors.New("the account name doesn't exist")

--- a/spinnaker/urls.go
+++ b/spinnaker/urls.go
@@ -50,7 +50,7 @@ func (s Spinnaker) accountURL(account string) string {
 func (s Spinnaker) accountsURL(expanded bool) string {
 	var qs string
 	if expanded {
-		qs = "?expanded=true"
+		qs = "?expand=true"
 	}
 	return fmt.Sprintf("%s/credentials/"+qs, s.endpoint)
 }

--- a/spinnaker/urls.go
+++ b/spinnaker/urls.go
@@ -46,6 +46,11 @@ func (s Spinnaker) accountURL(account string) string {
 	return fmt.Sprintf("%s/credentials/%s", s.endpoint, account)
 }
 
+// credentialsURL returns the Spinnaker endpoint for retrieving all credentials
+func (s Spinnaker) credentialsURL() string {
+	return fmt.Sprintf("%s/credentials/", s.endpoint)
+}
+
 // instanceURL returns the spinnaker URL for an instance
 func (s Spinnaker) instanceURL(account string, region string, id string) string {
 	return fmt.Sprintf("%s/instances/%s/%s/%s", s.endpoint, account, region, id)

--- a/spinnaker/urls.go
+++ b/spinnaker/urls.go
@@ -46,9 +46,13 @@ func (s Spinnaker) accountURL(account string) string {
 	return fmt.Sprintf("%s/credentials/%s", s.endpoint, account)
 }
 
-// credentialsURL returns the Spinnaker endpoint for retrieving all credentials
-func (s Spinnaker) credentialsURL() string {
-	return fmt.Sprintf("%s/credentials/", s.endpoint)
+// accountsURL returns the Spinnaker endpoint for retrieving all accounts, with details or not
+func (s Spinnaker) accountsURL(expanded bool) string {
+	var qs string
+	if expanded {
+		qs = "?expanded=true"
+	}
+	return fmt.Sprintf("%s/credentials/"+qs, s.endpoint)
 }
 
 // instanceURL returns the spinnaker URL for an instance


### PR DESCRIPTION
Fix #52 

```sh
spinnaker@hal-123:~$ chaosmonkey eligible sireeapp1 {wrongAccountName}
retrieve cloud provider failed: json unmarshal failed: unexpected end of JSON input
```

## Why 
Behind the curtain, `eligible` asks for the CloudProvider name associated to the user typed. For getting this information, one calls the `/credentials/{wrongAccountName}` spinnaker API route. But, obviously, this route doesn't exist. The flaw occurs in this case, and the app can't distinguish the events : 
* the JSON response is malformed,
* there's no user with this name.

## Technical solution
I used [another route](https://github.com/spinnaker/gate/blob/921285f4f02ed5ebc46411ec100459d171292fbd/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy#L37L44) proposed by the API. This route returns all accounts attached to the instance, and I simply check if `{wrongAccountName}` is present for displaying a good error message.

---

~~NB1 : My last changes weren't verified as deeply as I used to do. I broke my test VM instance before finishing so let me know if you want me to repair it before review and test or if we start the review now.~~
NB2 : I'm not an expert in Golang so do not hesitate to criticise, I want to improve my knowledges.