### PR TITLE
[mysql] startMySQLContainer: Fix goroutine leak

### DIFF
--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -117,7 +117,7 @@ func startMySQLContainer() (*exec.Cmd, error) {
 		return nil, err
 	}
 
-	ch := make(chan int)
+	ch := make(chan int, 1)
 
 	readyString := "mysqld: ready for connections"
 


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

This PR fixes a goroutine leak. If the goroutine writing to the channel ch times out (> 30 seconds), then the goroutine is left hanging waiting for a corresponding reader. To avoid this, use a buffered channel.