### PR TITLE
Correct typo for 'listening' from 'lstening'

### DIFF
--- a/docs/Configuration-file-format.md
+++ b/docs/Configuration-file-format.md
@@ -78,7 +78,7 @@ outage_checker = ""
 
 [database]
 host = ""                # database host
-port = 3306              # tcp port that the database is lstening on
+port = 3306              # tcp port that the database is listening on
 user = ""                # database user
 encrypted_password = ""  # password for database auth, encrypted by decryptor
 name = ""                # name of database that contains chaos monkey data


### PR DESCRIPTION
Searched the rest of the repo and cannot find any other matches for this typo:
```
grep lstening . -R
./docs/Configuration-file-format.md:port = 3306              # tcp port that the database is lstening on
```