### PR TITLE
Add /v2 to package to comply with golang's semantic import versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.out
+.idea/

--- a/cal/cal_test.go
+++ b/cal/cal_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Netflix/chaosmonkey/cal"
+	"github.com/Netflix/chaosmonkey/v2/cal"
 )
 
 var weekdayTests = []struct {

--- a/chaosmonkey_test.go
+++ b/chaosmonkey_test.go
@@ -17,7 +17,7 @@ package chaosmonkey_test
 import (
 	"testing"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 )
 
 func TestExceptionMatches(t *testing.T) {

--- a/cmd/chaosmonkey/main.go
+++ b/cmd/chaosmonkey/main.go
@@ -18,17 +18,17 @@ Chaos Monkey randomly terminates instances.
 package main
 
 import (
-	"github.com/Netflix/chaosmonkey/command"
+	"github.com/Netflix/chaosmonkey/v2/command"
 
 	// These are anonymous imported so that the related Get* methods (e.g.,
 	// GetDecryptor) are picked up.
 
-	_ "github.com/Netflix/chaosmonkey/constrainer"
-	_ "github.com/Netflix/chaosmonkey/decryptor"
-	_ "github.com/Netflix/chaosmonkey/env"
-	_ "github.com/Netflix/chaosmonkey/errorcounter"
-	_ "github.com/Netflix/chaosmonkey/outage"
-	_ "github.com/Netflix/chaosmonkey/tracker"
+	_ "github.com/Netflix/chaosmonkey/v2/constrainer"
+	_ "github.com/Netflix/chaosmonkey/v2/decryptor"
+	_ "github.com/Netflix/chaosmonkey/v2/env"
+	_ "github.com/Netflix/chaosmonkey/v2/errorcounter"
+	_ "github.com/Netflix/chaosmonkey/v2/outage"
+	_ "github.com/Netflix/chaosmonkey/v2/tracker"
 )
 
 func main() {

--- a/command/chaosmonkey.go
+++ b/command/chaosmonkey.go
@@ -25,16 +25,16 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/clock"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/mysql"
-	"github.com/Netflix/chaosmonkey/schedstore"
-	"github.com/Netflix/chaosmonkey/schedule"
-	"github.com/Netflix/chaosmonkey/spinnaker"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/clock"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
+	"github.com/Netflix/chaosmonkey/v2/schedstore"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
+	"github.com/Netflix/chaosmonkey/v2/spinnaker"
 )
 
 // Version is the version number

--- a/command/dumpconfig.go
+++ b/command/dumpconfig.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 	"github.com/davecgh/go-spew/spew"
 )
 

--- a/command/dumpmonkeyconfig.go
+++ b/command/dumpmonkeyconfig.go
@@ -17,7 +17,7 @@ package command
 import (
 	"fmt"
 
-	"github.com/Netflix/chaosmonkey/config"
+	"github.com/Netflix/chaosmonkey/v2/config"
 )
 
 // DumpMonkeyConfig dumps the monkey-level config parameters to stdout

--- a/command/eligible.go
+++ b/command/eligible.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/eligible"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/eligible"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 // Eligible prints out a list of instance ids eligible for termination

--- a/command/fetchschedule.go
+++ b/command/fetchschedule.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/schedstore"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/schedstore"
 )
 
 // FetchSchedule executes the "fetch-schedule" command. This checks if there

--- a/command/install.go
+++ b/command/install.go
@@ -16,8 +16,8 @@ package command
 
 import (
 	"fmt"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/mysql"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
 	"io/ioutil"
 	"log"
 	"os"

--- a/command/install_test.go
+++ b/command/install_test.go
@@ -16,9 +16,9 @@ package command
 
 import (
 	"fmt"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/mock"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 	"github.com/pkg/errors"
 	"io/ioutil"
 	"testing"

--- a/command/migrate.go
+++ b/command/migrate.go
@@ -15,7 +15,7 @@
 package command
 
 import (
-	"github.com/Netflix/chaosmonkey/mysql"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
 	"log"
 )
 

--- a/command/outage.go
+++ b/command/outage.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 )
 
 // Outage prints out "true" if an ongoing outage, else "false"

--- a/command/regions.go
+++ b/command/regions.go
@@ -16,8 +16,8 @@ package command
 
 import (
 	"fmt"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/spinnaker"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/spinnaker"
 	"github.com/SmartThingsOSS/frigga-go"
 	"os"
 )

--- a/command/schedule.go
+++ b/command/schedule.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/schedstore"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/schedstore"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // Schedule executes the "schedule" command. This defines the schedule

--- a/command/schedule_int_test.go
+++ b/command/schedule_int_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/constrainer"
-	"github.com/Netflix/chaosmonkey/mock"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/constrainer"
+	"github.com/Netflix/chaosmonkey/v2/mock"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // TestSchedule verifies the schedule command generates a cron file with

--- a/command/schedule_test.go
+++ b/command/schedule_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // addToSchedule schedules instanceId for termination at timeString

--- a/command/terminate.go
+++ b/command/terminate.go
@@ -17,8 +17,8 @@ package command
 import (
 	"log"
 
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/term"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/term"
 )
 
 // Terminate executes the "terminate" command. This selects an instance

--- a/config/monkey.go
+++ b/config/monkey.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/Netflix/chaosmonkey/config/param"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
 )
 
 // Monkey is is a config implementation backed by viper

--- a/config/monkey_test.go
+++ b/config/monkey_test.go
@@ -16,7 +16,7 @@ package config
 
 import (
 	"fmt"
-	"github.com/Netflix/chaosmonkey/config/param"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
 	"testing"
 )
 

--- a/constrainer/constrainer.go
+++ b/constrainer/constrainer.go
@@ -15,9 +15,9 @@
 package constrainer
 
 import (
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // NullConstrainer is a no-op constrainer

--- a/decryptor/decryptor.go
+++ b/decryptor/decryptor.go
@@ -15,9 +15,9 @@
 package decryptor
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 	"github.com/pkg/errors"
 )
 

--- a/deploy/eligible_instance_groups.go
+++ b/deploy/eligible_instance_groups.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 // EligibleInstanceGroups returns a slice of InstanceGroups that represent
@@ -30,14 +30,14 @@ import (
 // termination, not when considering groups of eligible instances.
 //
 // The way instances are divided into group will depend on
-//  * the grouping configuration for the app (cluster, stack, app)
-//  * whether regions are independent
+//   - the grouping configuration for the app (cluster, stack, app)
+//   - whether regions are independent
 //
 // The returned InstanceGroups are guaranteed to contain at least one instance
 // each
 //
 // Preconditions:
-//   * app is enabled for Chaos Monkey
+//   - app is enabled for Chaos Monkey
 func (app *App) EligibleInstanceGroups(cfg chaosmonkey.AppConfig) []grp.InstanceGroup {
 	if !cfg.Enabled {
 		log.Fatalf("app %s unexpectedly disabled", app.Name())

--- a/deploy/eligible_instance_groups_test.go
+++ b/deploy/eligible_instance_groups_test.go
@@ -18,8 +18,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 type groupList []grp.InstanceGroup

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -16,11 +16,11 @@
 package deps
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/clock"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/clock"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 var (

--- a/eligible/eligible.go
+++ b/eligible/eligible.go
@@ -16,9 +16,9 @@
 package eligible
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 	"github.com/SmartThingsOSS/frigga-go"
 	"github.com/pkg/errors"
 	"strings"

--- a/eligible/eligible_test.go
+++ b/eligible/eligible_test.go
@@ -1,10 +1,10 @@
 package eligible
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	D "github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/mock"
+	"github.com/Netflix/chaosmonkey/v2"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 	"sort"
 	"testing"
 )

--- a/eligible/instances_canary_test.go
+++ b/eligible/instances_canary_test.go
@@ -17,9 +17,9 @@ package eligible
 import (
 	"testing"
 
-	D "github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/mock"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 )
 
 // Test that canaries are not considered eligible instances

--- a/eligible/instances_test.go
+++ b/eligible/instances_test.go
@@ -17,10 +17,10 @@ package eligible
 import (
 	"testing"
 
-	"github.com/Netflix/chaosmonkey"
-	D "github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/mock"
+	"github.com/Netflix/chaosmonkey/v2"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 )
 
 // mockDeployment returns a deploy.Deployment object mock for testing

--- a/env/env.go
+++ b/env/env.go
@@ -17,9 +17,9 @@
 package env
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 )
 
 // notTestEnv is an environment that does not report as a test env

--- a/errorcounter/errorcounter.go
+++ b/errorcounter/errorcounter.go
@@ -15,9 +15,9 @@
 package errorcounter
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 	"github.com/pkg/errors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Netflix/chaosmonkey
+module github.com/Netflix/chaosmonkey/v2
 
 go 1.19
 

--- a/grp/grp_test.go
+++ b/grp/grp_test.go
@@ -17,7 +17,7 @@ package grp_test
 import (
 	"testing"
 
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 func TestNewAppWithRegion(t *testing.T) {

--- a/mock/configgetter.go
+++ b/mock/configgetter.go
@@ -14,7 +14,7 @@
 
 package mock
 
-import "github.com/Netflix/chaosmonkey"
+import "github.com/Netflix/chaosmonkey/v2"
 
 // ConfigGetter implements chaosmonkey.Getter
 type ConfigGetter struct {

--- a/mock/deployment.go
+++ b/mock/deployment.go
@@ -17,7 +17,7 @@ package mock
 import (
 	"github.com/pkg/errors"
 
-	D "github.com/Netflix/chaosmonkey/deploy"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
 )
 
 const cloudProvider = "aws"
@@ -25,8 +25,10 @@ const cloudProvider = "aws"
 // Dep returns a mock implementation of deploy.Deployment
 // Dep has 4 apps: foo, bar, baz, quux
 // Each app runs in 1 account:
-//    foo, bar, baz run in prod
-//    quux runs in test
+//
+//	foo, bar, baz run in prod
+//	quux runs in test
+//
 // Each app has one cluster: foo-prod, bar-prod, baz-prod
 // Each cluster runs in one region: us-east-1
 // Each cluster contains 1 AZ with two instances
@@ -45,12 +47,13 @@ func Dep() D.Deployment {
 
 // NewDeployment returns a mock implementation of deploy.Deployment
 // Pass in a deploy.AppMap, for example:
-//  map[string]deploy.AppMap{
-// 		"foo":  deploy.AppMap{"prod": {"foo-prod": {"us-east-1": {"foo-prod-v001": []string{"i-d3e3d611", "i-63f52e25"}}}}},
-// 		"bar":  deploy.AppMap{"prod": {"bar-prod": {"us-east-1": {"bar-prod-v011": []string{"i-d7f06d45", "i-ce433cf1"}}}}},
-// 		"baz":  deploy.AppMap{"prod": {"baz-prod": {"us-east-1": {"baz-prod-v004": []string{"i-25b86646", "i-573d46d5"}}}}},
-// 		"quux": deploy.AppMap{"test": {"quux-test": {"us-east-1": {"quux-test-v004": []string{"i-25b866ab", "i-892d46d5"}}}}},
-// 	}
+//
+//	 map[string]deploy.AppMap{
+//			"foo":  deploy.AppMap{"prod": {"foo-prod": {"us-east-1": {"foo-prod-v001": []string{"i-d3e3d611", "i-63f52e25"}}}}},
+//			"bar":  deploy.AppMap{"prod": {"bar-prod": {"us-east-1": {"bar-prod-v011": []string{"i-d7f06d45", "i-ce433cf1"}}}}},
+//			"baz":  deploy.AppMap{"prod": {"baz-prod": {"us-east-1": {"baz-prod-v004": []string{"i-25b86646", "i-573d46d5"}}}}},
+//			"quux": deploy.AppMap{"test": {"quux-test": {"us-east-1": {"quux-test-v004": []string{"i-25b866ab", "i-892d46d5"}}}}},
+//		}
 func NewDeployment(apps map[string]D.AppMap) D.Deployment {
 	return &Deployment{apps}
 }

--- a/mock/deps.go
+++ b/mock/deps.go
@@ -18,11 +18,11 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/clock"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/clock"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 )
 
 type (

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -16,7 +16,7 @@
 // for testing
 package mock
 
-import D "github.com/Netflix/chaosmonkey/deploy"
+import D "github.com/Netflix/chaosmonkey/v2/deploy"
 
 // AppFactory creates App objects used for testing
 type AppFactory struct {

--- a/mock/terminator.go
+++ b/mock/terminator.go
@@ -14,7 +14,7 @@
 
 package mock
 
-import "github.com/Netflix/chaosmonkey"
+import "github.com/Netflix/chaosmonkey/v2"
 
 // Terminator implements term.terminator
 type Terminator struct {

--- a/mysql/checker_test.go
+++ b/mysql/checker_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build docker
 // +build docker
 
 // The tests in this package use docker to test against a mysql:5.6 database
@@ -24,9 +25,9 @@ import (
 	"testing"
 	"time"
 
-	c "github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/mock"
-	"github.com/Netflix/chaosmonkey/mysql"
+	c "github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/mock"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
 )
 
 var endHour = 15 // 3PM

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -23,15 +23,15 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/cal"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/migration"
-	"github.com/Netflix/chaosmonkey/schedstore"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/cal"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/migration"
+	"github.com/Netflix/chaosmonkey/v2/schedstore"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 	"github.com/rubenv/sql-migrate"
 	"log"
 )
@@ -376,27 +376,26 @@ func respectsMinTimeBetweenKills(tx *sql.Tx, now time.Time, term chaosmonkey.Ter
 // workday ends at 5PM, this would be 17
 // loc is the location that corresponds to endHour, e.g. America/Los_Angeles for PST
 //
-// The returned time will be in UTC
+// # The returned time will be in UTC
 //
 // If days=1, then we allow
 // kills each day, so the most recent kill will be at the
 // end of the previous workday. For example:
 //
-//  days: 1
-//  endHour: 17 (i.e. work day ends at 5PM local time)
-//  loc:  America/Los_Angeles (PST)
-//  chrono.Now(): Wed, Dec. 16, 2015 2:30 PM PST
-//  Output: Tue, Dec. 15, 2015 5:00 PM PST
-//
+//	days: 1
+//	endHour: 17 (i.e. work day ends at 5PM local time)
+//	loc:  America/Los_Angeles (PST)
+//	chrono.Now(): Wed, Dec. 16, 2015 2:30 PM PST
+//	Output: Tue, Dec. 15, 2015 5:00 PM PST
 //
 // If days=0, returns the the current date, with
 // the time set to endHour. For example:
 //
-//  days: 0
-//  endHour: 17 (i.e. work day ends at 5PM local time)
-//  loc:  America/Los_Angeles (PST)
-//  chrono.Now(): Wed, Dec. 16, 2015 2:30 PM PST
-//  Output: Wed, Dec. 16, 2015 5:00 PM PST
+//	days: 0
+//	endHour: 17 (i.e. work day ends at 5PM local time)
+//	loc:  America/Los_Angeles (PST)
+//	chrono.Now(): Wed, Dec. 16, 2015 2:30 PM PST
+//	Output: Wed, Dec. 16, 2015 5:00 PM PST
 //
 // noKillsSince returns the a datetime that is the last allowed time that a kill
 // is permitted to have happened.

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build docker
 // +build docker
 
 // The tests in this package use docker to test against a mysql:5.6 database
@@ -37,7 +38,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Netflix/chaosmonkey/mysql"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
 	"github.com/pkg/errors"
 )
 

--- a/mysql/schedstore_test.go
+++ b/mysql/schedstore_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build docker
 // +build docker
 
 // The tests in this package use docker to test against a mysql:5.6 database
@@ -26,10 +27,10 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 
-	"github.com/Netflix/chaosmonkey/grp"
-	"github.com/Netflix/chaosmonkey/mysql"
-	"github.com/Netflix/chaosmonkey/schedstore"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2/grp"
+	"github.com/Netflix/chaosmonkey/v2/mysql"
+	"github.com/Netflix/chaosmonkey/v2/schedstore"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // Test we can publish and then retrieve a schedule

--- a/outage/outage.go
+++ b/outage/outage.go
@@ -16,9 +16,9 @@
 package outage
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 	"github.com/pkg/errors"
 )
 

--- a/schedstore/schedstore.go
+++ b/schedstore/schedstore.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 // ErrAlreadyExists is returned when calling Publish if a schedule already

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -24,10 +24,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 // Populate populates the termination schedule with the random
@@ -207,8 +207,9 @@ func (e *Entry) Equal(o *Entry) bool {
 
 // Crontab returns a termination command for the Entry, in crontab format.
 // It takes as arguments:
-//  - the path to the termination executable
-//  - the account that should execute the job
+//   - the path to the termination executable
+//   - the account that should execute the job
+//
 // The returned string is not terminated by a newline.
 func (e *Entry) Crontab(termPath, account string) string {
 	// From https://en.wikipedia.org/wiki/Cron
@@ -273,8 +274,8 @@ func (t ByTime) Less(i, j int) bool { return t[i].Time.Before(t[j].Time) }
 
 // Crontab returns a schedule of termination commands in crontab format
 // It takes as arguments:
-//  - the path to the executable that terminates an instance
-//  - the account that should execute the job
+//   - the path to the executable that terminates an instance
+//   - the account that should execute the job
 func (s Schedule) Crontab(exPath string, account string) []byte {
 	var result bytes.Buffer
 

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -18,11 +18,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/mock"
-	"github.com/Netflix/chaosmonkey/schedule"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/mock"
+	"github.com/Netflix/chaosmonkey/v2/schedule"
 )
 
 func TestPopulate(t *testing.T) {

--- a/spinnaker/config.go
+++ b/spinnaker/config.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 
 	"github.com/pkg/errors"
 )

--- a/spinnaker/fromjson.go
+++ b/spinnaker/fromjson.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 
 	"github.com/pkg/errors"
 )
@@ -26,71 +26,70 @@ import (
 // FromJSON takes a Spinnaker JSON representation of an app
 // and returns a Chaos Monkey config
 // Example:
-//   {
-//       "name": "abc",
-//       "attributes": {
-//         "chaosMonkey": {
-//         "enabled": true,
-//           "meanTimeBetweenKillsInWorkDays": 5,
-//           "minTimeBetweenKillsInWorkDays": 1,
-//           "grouping": "cluster",
-//           "regionsAreIndependent": false,
-//         },
-//         "exceptions" : [
-//             {
-//                 "account": "test",
-//                 "stack": "*",
-//                 "cluster": "*",
-//                 "region": "*"
-//             },
-//             {
-//                 "account": "prod",
-//                 "stack": "*",
-//                 "cluster": "*",
-//                 "region": "eu-west-1"
-//             },
-//         ]
-//       }
-//   }
 //
+//	{
+//	    "name": "abc",
+//	    "attributes": {
+//	      "chaosMonkey": {
+//	      "enabled": true,
+//	        "meanTimeBetweenKillsInWorkDays": 5,
+//	        "minTimeBetweenKillsInWorkDays": 1,
+//	        "grouping": "cluster",
+//	        "regionsAreIndependent": false,
+//	      },
+//	      "exceptions" : [
+//	          {
+//	              "account": "test",
+//	              "stack": "*",
+//	              "cluster": "*",
+//	              "region": "*"
+//	          },
+//	          {
+//	              "account": "prod",
+//	              "stack": "*",
+//	              "cluster": "*",
+//	              "region": "eu-west-1"
+//	          },
+//	      ]
+//	    }
+//	}
 //
 // Example of disabled app:
-//   {
-//       "name": "abc",
-//       "attributes": {
-//         "chaosMonkey": {
-//         "enabled": false
-//         }
-//       }
-//    }
 //
+//	{
+//	    "name": "abc",
+//	    "attributes": {
+//	      "chaosMonkey": {
+//	      "enabled": false
+//	      }
+//	    }
+//	 }
 //
 // Example with whitelist
 //
-// 	  {
-//  	  "enabled": true,
-//  	  "grouping": "app",
-//  	  "meanTimeBetweenKillsInWorkDays": 4,
-//  	  "minTimeBetweenKillsInWorkDays": 1,
-//  	  "regionsAreIndependent": true,
-//  	  "exceptions": [
-//  	  	{
-//  	  	"account": "prod",
-//  	  	"region": "us-west-2",
-//  	  	"stack": "foo",
-//  	  	"detail": "bar"
-//  	  	}
-//  	  ],
-//  	  "whitelist": [
-//  	  	{
-//  	  	"account": "test",
-//  	  	"stack": "*",
-//  	  	"region": "*",
-//  	  	"detail": "*"
-//  	  	}
-//  	  ]
-// 	  }
-//
+//		  {
+//	 	  "enabled": true,
+//	 	  "grouping": "app",
+//	 	  "meanTimeBetweenKillsInWorkDays": 4,
+//	 	  "minTimeBetweenKillsInWorkDays": 1,
+//	 	  "regionsAreIndependent": true,
+//	 	  "exceptions": [
+//	 	  	{
+//	 	  	"account": "prod",
+//	 	  	"region": "us-west-2",
+//	 	  	"stack": "foo",
+//	 	  	"detail": "bar"
+//	 	  	}
+//	 	  ],
+//	 	  "whitelist": [
+//	 	  	{
+//	 	  	"account": "test",
+//	 	  	"stack": "*",
+//	 	  	"region": "*",
+//	 	  	"detail": "*"
+//	 	  	}
+//	 	  ]
+//		  }
 func fromJSON(js []byte) (*chaosmonkey.AppConfig, error) {
 	parsed := new(parsedJSON)
 	err := json.Unmarshal(js, parsed)

--- a/spinnaker/fromjson_test.go
+++ b/spinnaker/fromjson_test.go
@@ -17,7 +17,7 @@ package spinnaker
 import (
 	"testing"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 )
 
 func TestFromJSON(t *testing.T) {

--- a/spinnaker/spinnaker.go
+++ b/spinnaker/spinnaker.go
@@ -29,10 +29,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	D "github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 )
 
 // Spinnaker implements the deploy.Deployment interface by querying Spinnaker

--- a/spinnaker/terminator.go
+++ b/spinnaker/terminator.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 )
 
 const terminateType string = "terminateInstances"

--- a/spinnaker/terminator_test.go
+++ b/spinnaker/terminator_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Netflix/chaosmonkey/mock"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 )
 
 func TestKillJSONPayload(t *testing.T) {

--- a/term/term.go
+++ b/term/term.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/eligible"
-	"github.com/Netflix/chaosmonkey/grp"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/eligible"
+	"github.com/Netflix/chaosmonkey/v2/grp"
 )
 
 type leashedKiller struct {

--- a/term/term_ext_test.go
+++ b/term/term_ext_test.go
@@ -17,11 +17,11 @@ package term_test
 import (
 	"testing"
 
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	D "github.com/Netflix/chaosmonkey/deploy"
-	"github.com/Netflix/chaosmonkey/mock"
-	"github.com/Netflix/chaosmonkey/term"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	D "github.com/Netflix/chaosmonkey/v2/deploy"
+	"github.com/Netflix/chaosmonkey/v2/mock"
+	"github.com/Netflix/chaosmonkey/v2/term"
 )
 
 func TestEnabledAccounts(t *testing.T) {

--- a/term/terminate_test.go
+++ b/term/terminate_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/clock"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/config/param"
-	"github.com/Netflix/chaosmonkey/deps"
-	"github.com/Netflix/chaosmonkey/mock"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/clock"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/config/param"
+	"github.com/Netflix/chaosmonkey/v2/deps"
+	"github.com/Netflix/chaosmonkey/v2/mock"
 )
 
 func mockDeps() deps.Deps {

--- a/term/terminator.go
+++ b/term/terminator.go
@@ -17,7 +17,7 @@ package term
 import (
 	"fmt"
 
-	"github.com/Netflix/chaosmonkey"
+	"github.com/Netflix/chaosmonkey/v2"
 )
 
 // fake is a fake implementation of a terminator that just prints termination info but does nothing

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -16,9 +16,9 @@
 package tracker
 
 import (
-	"github.com/Netflix/chaosmonkey"
-	"github.com/Netflix/chaosmonkey/config"
-	"github.com/Netflix/chaosmonkey/deps"
+	"github.com/Netflix/chaosmonkey/v2"
+	"github.com/Netflix/chaosmonkey/v2/config"
+	"github.com/Netflix/chaosmonkey/v2/deps"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
Have to do this because we already had pre-existing 2.x releases.