### PR TITLE
Update for installation cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AWS, [GCE][gce-blogpost], and Kubernetes.
 To install the Chaos Monkey binary on your local machine:
 
 ```
-go get github.com/netflix/chaosmonkey/cmd/chaosmonkey
+go install github.com/Netflix/chaosmonkey/bin/chaosmonkey@latest
 ```
 
 ### How to deploy


### PR DESCRIPTION
Starting in Go 1.17, installing executable with go get is deprecated. go install may be used instead.