### PR TITLE
fix(mysql): Replace the deprecated system variable tx_isolation in MySQL 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
     - docker
 
 install:
-    - docker pull mysql:5.6
+    - docker pull mysql:8.0
     - go get golang.org/x/lint/golint
     - go get github.com/kisielk/errcheck
 

--- a/docs/How-to-deploy.md
+++ b/docs/How-to-deploy.md
@@ -6,12 +6,12 @@ for other users to get up and running quickly.
 ## Prerequisites
 
 * [Spinnaker]
-* MySQL (5.6 or later)
+* MySQL (8.0 or later)
 
 To use this version of Chaos Monkey, you must be using [Spinnaker] to manage your applications. Spinnaker is the
 continuous delivery platform that we use at Netflix.
 
-Chaos Monkey also requires a MySQL-compatible database, version 5.6 or later.
+Chaos Monkey also requires a MySQL-compatible database, version 8.0 or later.
 
 [Spinnaker]: http://www.spinnaker.io/
 

--- a/docs/Running-locally.md
+++ b/docs/Running-locally.md
@@ -8,5 +8,5 @@ describes how to start both of those up using Docker containers
 This will start up a MySQL container with the root password as `password`.
 
 ```bash
-docker run -e MYSQL_ROOT_PASSWORD=password -p3306:3306 mysql:5.6
+docker run -e MYSQL_ROOT_PASSWORD=password -p3306:3306 mysql:8.0
 ```

--- a/docs/dev/Running-tests.md
+++ b/docs/dev/Running-tests.md
@@ -18,7 +18,7 @@ root:password@tcp(127.0.0.1:3306)/
 ### Testing with Docker
 
 The simplest way to run these tests is to install Docker on your local machine.
-These tests use the `mysql:5.6` container (version 5.6 is used to ensure
+These tests use the `mysql:8.0` container (version 8.0 is used to ensure
 compatibility with [Amazon Aurora][1]).
 
 Note that if you are on macOS, you must use [Docker for Mac][2], not Docker
@@ -26,10 +26,10 @@ Toolbox. Otherwise, the Docker containers will not be accessible at 127.0.0.1.
 
 
 If you want to run these tests, ensure you have Docker installed locally, and
-grab the mysql:5.6 container:
+grab the mysql:8.0 container:
 
 ```bash
-docker pull mysql:5.6
+docker pull mysql:8.0
 ```
 
 Then run the tests with the `docker` tag, like this:

--- a/mysql/checker_test.go
+++ b/mysql/checker_test.go
@@ -15,7 +15,7 @@
 //go:build docker
 // +build docker
 
-// The tests in this package use docker to test against a mysql:5.6 database
+// The tests in this package use docker to test against a mysql:8.0 database
 // By default, the tests are off unless you pass the "-tags docker" flag
 // when running the test.
 

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -46,7 +46,7 @@ func TxDeadlock(err error) bool {
 	switch err := errors.Cause(err).(type) {
 	case *mysql.MySQLError:
 		// ER_LOCK_DEADLOCK
-		// See: https://dev.mysql.com/doc/refman/5.6/en/error-messages-server.html
+		// See: https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_lock_deadlock
 		return err.Number == 1213
 	default:
 		return false

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -242,10 +242,10 @@ func schedExists(tx *sql.Tx, date time.Time) (result bool, err error) {
 // See: https://github.com/go-sql-driver/mysql#dsn-data-source-name
 func dsn(host string, port int, user string, password string, dbname string) string {
 	params := map[string]string{
-		"tx_isolation": "SERIALIZABLE", // we need serializable transactions for atomic test & set behavior
-		"parseTime":    "true",         // enable us to use sql.Rows.Scan to read time.Time objects from queries
-		"loc":          "UTC",          // Scan'd time.Times should be treated as being in UTC time zone
-		"time_zone":    "UTC",          // MySQL should interpret DATETIME values as being in UTC
+		"transaction_isolation": "SERIALIZABLE", // we need serializable transactions for atomic test & set behavior
+		"parseTime":             "true",         // enable us to use sql.Rows.Scan to read time.Time objects from queries
+		"loc":                   "UTC",          // Scan'd time.Times should be treated as being in UTC time zone
+		"time_zone":             "UTC",          // MySQL should interpret DATETIME values as being in UTC
 	}
 
 	var ss []string

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -15,7 +15,7 @@
 //go:build docker
 // +build docker
 
-// The tests in this package use docker to test against a mysql:5.6 database
+// The tests in this package use docker to test against a mysql:8.0 database
 // By default, the tests are off unless you pass the "-tags docker" flag
 // when running the test.
 //
@@ -107,7 +107,7 @@ func TestMain(m *testing.M) {
 // startMySQLContainer starts a MySQL docker container
 // Returns the Cmd object associated with the process
 func startMySQLContainer() (*exec.Cmd, error) {
-	cmd := exec.Command("docker", "run", "-e", "MYSQL_ROOT_PASSWORD="+password, fmt.Sprintf("-p3306:%d", port), "mysql:5.6")
+	cmd := exec.Command("docker", "run", "-e", "MYSQL_ROOT_PASSWORD="+password, fmt.Sprintf("-p3306:%d", port), "mysql:8.0")
 	pipe, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, err

--- a/mysql/schedstore_test.go
+++ b/mysql/schedstore_test.go
@@ -15,7 +15,7 @@
 //go:build docker
 // +build docker
 
-// The tests in this package use docker to test against a mysql:5.6 database
+// The tests in this package use docker to test against a mysql:8.0 database
 // By default, the tests are off unless you pass the "-tags docker" flag
 // when running the test.
 


### PR DESCRIPTION
AWS Aurora 2 is being deprecated and replaced by Aurora 3. Aurora 3 is baed on MySQL 8.0. 

This PR is to make a few updates to switch to MySQL 8.0 in docs and tests to keep compatibility with AWS Aurora. It also takes care of a deprecated system variable in MySQL 8.0:
- Starting with MySQL 8.0.3, the `tx_isolation` system variable is deprecated and replaced with `transaction_isolation`.