### PR TITLE
Fix: Broken build status badge in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/chaosmonkey.svg)](OSSMETADATA) [![Build Status][travis-badge]][travis] [![GoDoc][godoc-badge]][godoc] [![GoReportCard][report-badge]][report]
 
 [travis-badge]: https://travis-ci.com/Netflix/chaosmonkey.svg?branch=master
-[travis]: https://api.travis-ci.com/Netflix/chaosmonkey.svg?branch=master
+[travis]: https://app.travis-ci.com/github/Netflix/chaosmonkey/builds/273818363
 [godoc-badge]: https://godoc.org/github.com/Netflix/chaosmonkey?status.svg
 [godoc]: https://godoc.org/github.com/Netflix/chaosmonkey
 [report-badge]: https://goreportcard.com/badge/github.com/Netflix/chaosmonkey

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/chaosmonkey.svg)](OSSMETADATA) [![Build Status][travis-badge]][travis] [![GoDoc][godoc-badge]][godoc] [![GoReportCard][report-badge]][report]
 
 [travis-badge]: https://travis-ci.com/Netflix/chaosmonkey.svg?branch=master
-[travis]: https://travis-ci.com/Netflix/chaosmonkey
+[travis]: https://api.travis-ci.com/Netflix/chaosmonkey.svg?branch=master
 [godoc-badge]: https://godoc.org/github.com/Netflix/chaosmonkey?status.svg
 [godoc]: https://godoc.org/github.com/Netflix/chaosmonkey
 [report-badge]: https://goreportcard.com/badge/github.com/Netflix/chaosmonkey

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/chaosmonkey.svg)](OSSMETADATA) [![Build Status][travis-badge]][travis] [![GoDoc][godoc-badge]][godoc] [![GoReportCard][report-badge]][report]
 
 [travis-badge]: https://travis-ci.com/Netflix/chaosmonkey.svg?branch=master
-[travis]: https://app.travis-ci.com/github/Netflix/chaosmonkey/builds/273818363
+[travis]: https://app.travis-ci.com/github/Netflix/chaosmonkey/builds
 [godoc-badge]: https://godoc.org/github.com/Netflix/chaosmonkey?status.svg
 [godoc]: https://godoc.org/github.com/Netflix/chaosmonkey
 [report-badge]: https://goreportcard.com/badge/github.com/Netflix/chaosmonkey


### PR DESCRIPTION
Issue Closed : #104  

This PR fixes the broken build status badge in the README file:
- Updated the badge link to point to the correct URL.